### PR TITLE
Custom table support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,28 @@ Adds a WP-CLI command that scrambles user email addresses. Useful for preventing
 - Download and install the file like any other WordPress plugin on your site.
 - Activate as a normal WordPress plugin or drop the `wds-user-email-scrambler.php` file into `/mu-plugins`
 
+## Arguments
+
+- `--ignored-domains=<domains>` - Comma-separated list of domains to exclude from the scrambling process.
+- `--table=<table>` - Table to target for scrambling. Defaults to `users`.
+- `--field=<field>` - Field to target for scramlbing. Defaults to `user_email`.
+- `--where-field=<field>`, `--where-value=<value>` - Field and field value used to target specific records via a where clause: `WHERE <field> = <value>`.
+
 ## Usage
 
 - Use `wp db export before-scramble.sql` to backup your database before scrambling.
 - Run the `wp scramble-user-emails` command. **It is highly recommended** to specify some ignored domains.
+- By default, the command applies to the `user_email` field in the `users` table. Use the `--table` and `--field` arguments to target a field in another table.
+- Use the `--where-field` and `--where-value` to target specific records for scrambling.
 
 **Specifying Ignored Domains**
 
 - If you run `wp scramble-user-emails --ignored-domains="webdevstudios.com, wdslab.com"` for example, then any user email that ends with `@webdevstudios.com` or `@wdslab.com` will be ignored.
 - This is useful for preserving, for example, admin email addresses or author email addresses.
+
+**Specifying custom tables**
+
+- If you run `wp scramble-user-emails --table=postmeta --field=meta_value --where-field=meta_key --where-value="_billing_email"`, the `meta_value` for all records in the `postmeta` table with `meta_key = "_billing_email"` will be scrambled.
 
 ## Example
 
@@ -29,5 +42,18 @@ wp scramble-user-emails --ignored-domains="webdevstudios.com, okeeffemuseum.org,
 
 **After:**
 ![after-screenshot](https://i.imgur.com/nFR98ku.png)
+
+## Example with specified target table and `WHERE` clause arguments
+
+**Before:**
+![before-screenshot](https://i.imgur.com/qmPNnbf.png)
+
+**Command**
+```
+wp scramble-user-emails --ignored-domains="webdevstudios.com" --table=postmeta --field=meta_value --where-field=meta_key --where-value="_billing_email"
+```
+
+**After:**
+![after-screenshot](https://i.imgur.com/fT1dk2L.png)
 
 

--- a/wds-user-email-scrambler.php
+++ b/wds-user-email-scrambler.php
@@ -109,6 +109,7 @@ final class UserEmailScrambler {
 	private function initialize_batch_process() {
 		$this->table = $this->get_target_table();
 		$field       = $this->get_target_field();
+		$key         = $this->get_target_table_key();
 		$user_ids        = $this->get_user_ids_to_scramble();
 		$user_id_batches = array_chunk( $user_ids, 30, true );
 
@@ -138,6 +139,27 @@ final class UserEmailScrambler {
 		}
 
 		return $this->check_table_exists( trim( $this->assoc_args['table'] ) );
+	}
+
+	/**
+	 * Get primary key of target table.
+	 *
+	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
+	 * @since  0.0.2
+	 *
+	 * @return string Primary key name.
+	 */
+	private function get_target_table_key() {
+		global $wpdb;
+
+		$response = $wpdb->get_row( "SHOW KEYS FROM {$this->table} WHERE Key_name = 'PRIMARY'" ); // phpcs:ignore WordPress.DB.PreparedSQL -- Okay use of unprepared variable for table name in SQL.
+
+		// Output error if primary key not available.
+		if ( null === $response || ! isset( $response->Column_name ) ) { // phpcs:ignore WordPress.NamingConventions -- Okay property name.
+			WP_CLI::error( esc_html__( 'Something went wrong. Supplied table does not have a primary key. Please check table schema and try again.', 'wds-user-email-scrambler' ) );
+		}
+
+		return $response->Column_name; // phpcs:ignore WordPress.NamingConventions -- Okay property name.
 	}
 
 	/**

--- a/wds-user-email-scrambler.php
+++ b/wds-user-email-scrambler.php
@@ -68,6 +68,15 @@ final class UserEmailScrambler {
 	private $table = '';
 
 	/**
+	 * Target field name.
+	 *
+	 * @since 0.0.2
+	 *
+	 * @var string
+	 */
+	private $field = '';
+
+	/**
 	 * Callback for invocation of the command from cli.
 	 *
 	 * @author George Gecewicz <george.gecewicz@webdevstudios.com>
@@ -108,7 +117,7 @@ final class UserEmailScrambler {
 	 */
 	private function initialize_batch_process() {
 		$this->table = $this->get_target_table();
-		$field       = $this->get_target_field();
+		$this->field = $this->get_target_field();
 		$key         = $this->get_target_table_key();
 		$user_ids        = $this->get_user_ids_to_scramble();
 		$user_id_batches = array_chunk( $user_ids, 30, true );
@@ -269,7 +278,7 @@ final class UserEmailScrambler {
 	 *
 	 * @return string
 	 */
-	private function get_ignored_domains_where_clause() {
+	private function get_ignored_domains_where_clause() : string {
 		$ignored_domains = $this->get_ignored_domains();
 
 		if ( empty( $ignored_domains ) ) {
@@ -280,9 +289,9 @@ final class UserEmailScrambler {
 
 		foreach ( $ignored_domains as $ignored_domain ) {
 			if ( 0 === count( $clauses ) ) {
-				$clauses[] = "WHERE user_email NOT LIKE '%{$ignored_domain}%'";
+				$clauses[] = "{$this->field} NOT LIKE '%{$ignored_domain}%'";
 			} else {
-				$clauses[] = "AND user_email NOT LIKE '%{$ignored_domain}%'";
+				$clauses[] = "AND {$this->field} NOT LIKE '%{$ignored_domain}%'";
 			}
 		}
 

--- a/wds-user-email-scrambler.php
+++ b/wds-user-email-scrambler.php
@@ -124,7 +124,7 @@ final class UserEmailScrambler {
 	private function get_user_ids_to_scramble() {
 		global $wpdb;
 
-		$users_table  = $this->get_users_table_name();
+		$users_table  = $this->get_table_name();
 		$where_clause = $this->get_ignored_domains_where_clause();
 
 		return $wpdb->get_results( "SELECT ID FROM {$users_table} {$where_clause}" ); // phpcs:disable WordPress.DB.PreparedSQL -- Okay use of unprepared variables SQL.
@@ -186,7 +186,7 @@ final class UserEmailScrambler {
 	private function scramble_batch_of_user_emails( $users, $total ) {
 		global $wpdb;
 
-		$users_table = $this->get_users_table_name();
+		$users_table = $this->get_table_name();
 
 		foreach ( $users as $user ) {
 			$wpdb->query(
@@ -219,16 +219,17 @@ final class UserEmailScrambler {
 	}
 
 	/**
-	 * Simple helper for getting wpdb-prefixed users table name.
+	 * Simple helper for getting wpdb-prefixed table name.
 	 *
 	 * @author George Gecewicz <george.gecewicz@webdevstudios.com>
 	 * @since 0.0.1
 	 *
-	 * @return string
+	 * @param  string $table Table name, defaults to 'users'.
+	 * @return string        Wpdb-prefixed table name.
 	 */
-	private function get_users_table_name() {
+	private function get_table_name( $table = 'users' ) {
 		global $wpdb;
-		return $wpdb->prefix . 'users';
+		return $wpdb->prefix . $table;
 	}
 }
 

--- a/wds-user-email-scrambler.php
+++ b/wds-user-email-scrambler.php
@@ -244,13 +244,12 @@ final class UserEmailScrambler {
 	 * @since 0.0.1
 	 *
 	 * @param  string $key Primary key for target table.
-	 * @return int
+	 * @return array       Array of record objects containing primary key IDs.
 	 */
-	private function get_record_ids_to_scramble( string $key ) {
+	private function get_record_ids_to_scramble( string $key ) : array {
 		global $wpdb;
 
 		$where_clause = $this->get_full_where_clause();
-
 
 		return $wpdb->get_results( "SELECT {$key} FROM {$this->table} {$where_clause}" ); // phpcs:disable WordPress.DB.PreparedSQL -- Okay use of unprepared variables SQL.
 	}

--- a/wds-user-email-scrambler.php
+++ b/wds-user-email-scrambler.php
@@ -133,7 +133,7 @@ final class UserEmailScrambler {
 	 *
 	 * @return string Table name, if exists.
 	 */
-	private function get_target_table() {
+	private function get_target_table() : string {
 		if ( ! isset( $this->assoc_args['table'] ) ) {
 			return 'users';
 		}
@@ -149,7 +149,7 @@ final class UserEmailScrambler {
 	 *
 	 * @return string Primary key name.
 	 */
-	private function get_target_table_key() {
+	private function get_target_table_key() : string {
 		global $wpdb;
 
 		$response = $wpdb->get_row( "SHOW KEYS FROM {$this->table} WHERE Key_name = 'PRIMARY'" ); // phpcs:ignore WordPress.DB.PreparedSQL -- Okay use of unprepared variable for table name in SQL.
@@ -170,7 +170,7 @@ final class UserEmailScrambler {
 	 *
 	 * @return string        Field name, if exists.
 	 */
-	private function get_target_field() {
+	private function get_target_field() : string {
 		if ( ! isset( $this->assoc_args['field'] ) ) {
 			return 'user_email';
 		}
@@ -187,7 +187,7 @@ final class UserEmailScrambler {
 	 * @param  string $table User-supplied, wpdb-prefixed table name.
 	 * @return string        Confirmed, wpdb-prefixed table name, if exists.
 	 */
-	private function check_table_exists( $table ) {
+	private function check_table_exists( string $table ) : string {
 		global $wpdb;
 
 		$table    = $this->get_table_name( $table );
@@ -215,7 +215,7 @@ final class UserEmailScrambler {
 	 * @param  string $field User-supplied field name.
 	 * @return string        Confirmed field name, if exists.
 	 */
-	private function check_field_exists( $field ) {
+	private function check_field_exists( string $field ) : string {
 		global $wpdb;
 
 		$response = $wpdb->get_col( "DESC {$this->table}" ); // phpcs:ignore WordPress.DB.PreparedSQL -- Okay use of unprepared variable for table name in SQL.

--- a/wds-user-email-scrambler.php
+++ b/wds-user-email-scrambler.php
@@ -59,6 +59,15 @@ final class UserEmailScrambler {
 	private $num_scrambled = 0;
 
 	/**
+	 * Wpdb-prefixed target table name.
+	 *
+	 * @since 0.0.2
+	 *
+	 * @var string
+	 */
+	private $table = '';
+
+	/**
 	 * Callback for invocation of the command from cli.
 	 *
 	 * @author George Gecewicz <george.gecewicz@webdevstudios.com>
@@ -98,8 +107,8 @@ final class UserEmailScrambler {
 	 * @since 0.0.1
 	 */
 	private function initialize_batch_process() {
-		$table = $this->get_target_table();
-		$field = $this->get_target_field( $table );
+		$this->table = $this->get_target_table();
+		$field       = $this->get_target_field();
 		$user_ids        = $this->get_user_ids_to_scramble();
 		$user_id_batches = array_chunk( $user_ids, 30, true );
 
@@ -137,15 +146,14 @@ final class UserEmailScrambler {
 	 * @author Rebekah Van Epps <rebekah.vanepps@webdevstudios.com>
 	 * @since  0.0.2
 	 *
-	 * @param  string $table Table name.
 	 * @return string        Field name, if exists.
 	 */
-	private function get_target_field( $table ) {
+	private function get_target_field() {
 		if ( ! isset( $this->assoc_args['field'] ) ) {
 			return 'user_email';
 		}
 
-		return $this->check_field_exists( trim( $this->assoc_args['field'] ), $table );
+		return $this->check_field_exists( trim( $this->assoc_args['field'] ) );
 	}
 
 	/**
@@ -183,13 +191,12 @@ final class UserEmailScrambler {
 	 * @since  0.0.2
 	 *
 	 * @param  string $field User-supplied field name.
-	 * @param  string $table Wpdb-prefixed table name.
 	 * @return string        Confirmed field name, if exists.
 	 */
-	private function check_field_exists( $field, $table ) {
+	private function check_field_exists( $field ) {
 		global $wpdb;
 
-		$response = $wpdb->get_col( "DESC {$table}" ); // phpcs:ignore WordPress.DB.PreparedSQL -- Okay use of unprepared variable for table name in SQL.
+		$response = $wpdb->get_col( "DESC {$this->table}" ); // phpcs:ignore WordPress.DB.PreparedSQL -- Okay use of unprepared variable for table name in SQL.
 
 		// Output error if field does not exist.
 		if ( false === array_search( $field, $response ) ) {

--- a/wds-user-email-scrambler.php
+++ b/wds-user-email-scrambler.php
@@ -3,7 +3,7 @@
  * Plugin Name: WDS User Email Scrambler
  * Description: Adds a WP-CLI command that scrambles user email addresses. Useful for preventing accidentally emailing real customers/users when testing mass or transactional email.
  * Plugin URI: https://github.org/webdevstudios/wds-user-email-scrambler
- * Version: 0.0.1
+ * Version: 0.0.2
  * Author: WebDevStudios
  * Author URI: https://www.webdevstudios.com/
  * License: GPL-3.0+
@@ -84,7 +84,7 @@ final class UserEmailScrambler {
 	 * @return void
 	 */
 	private function maybe_confirm_lack_of_ignored_domains() {
-		if ( ! empty( $this->assoc_args['ignored-domains'] ) ) {
+		if ( ! empty( $this->get_ignored_domains() ) ) {
 			return;
 		}
 


### PR DESCRIPTION
New version would support the command `wp scramble-user-emails --table=<table> --field=<field> --ignored-domains=<ignored> --where-field=<field> --where-value=<value>`

e.g., `wp scramble-user-emails --table=postmeta --field=meta_value --ignored-domains="webdevstudios.com" --where-field=meta_key --where-value="_billing_email"`

The original statement, i.e., `wp scramble-user-emails` will still function as expected and default to the users table.